### PR TITLE
Use `wp_generate_password()` to create CSP nonce instead of using `wp_create_nonce()`

### DIFF
--- a/strict-csp.php
+++ b/strict-csp.php
@@ -45,7 +45,7 @@ const VERSION = '0.3.1';
 function get_nonce(): string {
 	static $nonce = null;
 	if ( null === $nonce ) {
-		$nonce = wp_create_nonce( 'csp' );
+		$nonce = wp_generate_password( 43, false, false );
 	}
 	/**
 	 * Nonce.

--- a/strict-csp.php
+++ b/strict-csp.php
@@ -45,7 +45,7 @@ const VERSION = '0.3.1';
 function get_nonce(): string {
 	static $nonce = null;
 	if ( null === $nonce ) {
-		$nonce = wp_generate_password( 43, false, false );
+		$nonce = wp_generate_password( 22, false, false );
 	}
 	/**
 	 * Nonce.


### PR DESCRIPTION
This ensures that the nonce is unique for each page generation.

The length of 43 was originally chosen because this is the length of session tokens ([ref](https://github.com/WordPress/wordpress-develop/blob/8c374a5adb9bee9333a013a575b3aa0e828085be/src/wp-includes/class-wp-session-tokens.php#L145)), although this is probably overkill. I reduced it when consulting Gemini, which said that 22 characters is a sufficient length for a nonce consisting of `[A-Za-z0-9]` characters.